### PR TITLE
Add full stop after middle initial in JOSS paper

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -11,7 +11,7 @@ tags:
   - Horizons
 
 authors:
-  - name: Joseph D Carpinelli
+  - name: Joseph D. Carpinelli
     orcid: 0000-0001-8655-8125
     email: joseph.d.carpinelli@loopy.codes
     affiliations:


### PR DESCRIPTION
This is the only editorial issue to resolve following the [JOSS review](https://github.com/openjournals/joss-reviews/issues/6914).

I'm not 100% sure why GitHub's UI generated the changed line at the end. I expect it was to add a final newline to the file.